### PR TITLE
Bug fixes (correctly enable/disable StartDebug button, prevent unexpected edge dragging)

### DIFF
--- a/ControlsLibrary/Controls/Executor/ExecutorViewModel.cs
+++ b/ControlsLibrary/Controls/Executor/ExecutorViewModel.cs
@@ -49,7 +49,7 @@ namespace ControlsLibrary.Controls.Executor
         }
 
         private bool CanStartDebugCommandExecute(object p)
-            => string.IsNullOrEmpty(InputString);
+            => !string.IsNullOrEmpty(InputString);
 
         /// <summary>
         /// Resets executor state to initial

--- a/ControlsLibrary/Controls/Scene/Scene.xaml.cs
+++ b/ControlsLibrary/Controls/Scene/Scene.xaml.cs
@@ -513,7 +513,7 @@ namespace ControlsLibrary.Controls.Scene
                         zoomControl.Cursor = deletionCursor;
                         ClearEditMode();
                         ClearSelectMode();
-                        graphArea.SetEdgesDrag(true);
+                        graphArea.SetEdgesDrag(false);
                         return;
                     }
                 case SelectedTool.Edit:


### PR DESCRIPTION
Fixed bugs:
- `StartDebug` button used to be enabled if and only if input string is empty 
  * Now `StartDebug` button is enabled if and only if input string isn't empty
- It used to be possible to drag edges with delete tool during debugging visually detaching them from nodes (see gif below)
  * Now this dragging is disabled
![Unexpected edge dragging](https://user-images.githubusercontent.com/71839386/125537991-2863520d-7c3a-46ab-bd32-8214b72c9049.gif)
