### PR TITLE
Fix automaton serialization

### DIFF
--- a/ControlsLibrary/Controls/Scene/Scene.xaml.cs
+++ b/ControlsLibrary/Controls/Scene/Scene.xaml.cs
@@ -180,7 +180,7 @@ namespace ControlsLibrary.Controls.Scene
         public void Save(string path)
         {
             var datas = graphArea.ExtractSerializationData();
-            graphArea.ExtractSerializationData().ForEach(data =>
+            datas.ForEach(data =>
             {
                 if (data.Data.GetType() == typeof(NodeViewModel))
                 {


### PR DESCRIPTION
Fix automaton serialization by properly setting `HasLabel` to `false` for `NodeViewModel` data.
